### PR TITLE
Fixed uninitialized error caused by path

### DIFF
--- a/lib/Dancer/Template/MicroTemplate.pm
+++ b/lib/Dancer/Template/MicroTemplate.pm
@@ -22,12 +22,12 @@ sub init {
         line_start => '%',
         tag_start  => $self->config->{start_tag} || '<%',
         tag_end    => $self->config->{stop_tag} || '%>',
-
     };
 
-    my $path = path($self->{settings}{appdir}, 'views');
-    $mt_cfg->{include_path} = [$path]
-      if $self->{settings} && $self->{settings}{appdir};
+    if ($self->{settings} && $self->{settings}{appdir}) {
+        my $path = path($self->{settings}{appdir}, 'views');
+        $mt_cfg->{include_path} = [$path];
+    }
 
     $_engine = Text::MicroTemplate::File->new(%$mt_cfg);
 }
@@ -51,6 +51,21 @@ __END__
 =head1 NAME
 
 Dancer::Template::MicroTemplate - MicroTemplate wrapper for Dancer
+
+=head1 SYNOPSIS
+
+    use Dancer;
+    use Dancer::FileUtils 'path';
+    use Dancer::Template::MicroTemplate;
+
+    my $engine = Dancer::Template::MicroTemplate->new;
+    my $template = path('foo', 'bar.mt');
+    my $rendered = $engine->render($template, {template_var1 => 1, template_var2 => 2});
+
+    get '/' => sub {
+        $rendered
+    };
+    dance;
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION
Fixed uninitialized error caused when using path(), also updated documentation to have a working example in the synopsis section.

Found this error 'Use of uninitialized value in subroutine entry at /usr/local/share/perl5/Dancer/FileUtils.pm line 36.' when running the script below. It happens when $self->{settings}{appdir} isn't set. I replicated this with a base install of the lastest Dancer, Dancer::FileUtils, and Dancer::Template::MicroTemplate:
# !/usr/bin/env perl

use strict;
use warnings;

use Dancer;
use Dancer::FileUtils 'path';
use Dancer::Template::MicroTemplate;

my $engine = Dancer::Template::MicroTemplate->new;
my $template = path('foo', 'bar.mt');
my $rendered = $engine->render($template, {template_var1 => 1, template_var2 => 2});

get '/' => sub {
    "$rendered"
};

dance;

I was assigned this module (Dancer::Template::MicroTemplate) as part of the perl pull challenge (http://blogs.perl.org/users/neilb/2014/12/take-the-2015-cpan-pull-request-challenge.html)
